### PR TITLE
Fix for hang...?

### DIFF
--- a/ext/k3.cc
+++ b/ext/k3.cc
@@ -161,6 +161,8 @@ int work(
     // Let the client decide what we should do...
     std::getline(std::cin, cmd);
 
+    std::cout << "command: " << cmd << std::endl;
+
     if (cmd == "stop")
     {
       break;
@@ -277,6 +279,8 @@ int work(
       fprintf(stderr, "unknown command %s\n", cmd.c_str());
     }
   }
+
+  std::cout << "out of loop..." << std::to_string(::getpid()) << std::endl;
 }
 
 struct FileDeleter

--- a/ext/k3.cc
+++ b/ext/k3.cc
@@ -161,8 +161,6 @@ int work(
     // Let the client decide what we should do...
     std::getline(std::cin, cmd);
 
-    std::cout << "command: " << cmd << std::endl;
-
     if (cmd == "stop")
     {
       break;
@@ -279,8 +277,6 @@ int work(
       fprintf(stderr, "unknown command %s\n", cmd.c_str());
     }
   }
-
-  std::cout << "out of loop..." << std::to_string(::getpid()) << std::endl;
 }
 
 struct FileDeleter


### PR DESCRIPTION
This fixes an issue where standard_kaldi was hanging in get_final because no valid lines were being written to stdout.

The underlying bug is probably in `k3.cc`, but I don't have time right now to dive into that.

One weird symptom caused by this fix is that the `comm_{pid}` file doesn't get deleted for that final small chunk's kaldi pid.